### PR TITLE
fix compile issues due to update of dll

### DIFF
--- a/AGILE/SoundPlayer.cs
+++ b/AGILE/SoundPlayer.cs
@@ -90,7 +90,7 @@ namespace AGILE
                     if (voice1NoteNum < voice1Notes.Count)
                     {
                         Note note = voice1Notes[voice1NoteNum++];
-                        int[] psgBytes = note.Encode();
+                        byte[] psgBytes = note.Encode();
                         psg.write(psgBytes[3]);
                         psg.write(psgBytes[2]);
                         psg.write(psgBytes[4]);
@@ -108,7 +108,7 @@ namespace AGILE
                     if (voice2NoteNum < voice2Notes.Count)
                     {
                         Note note = voice2Notes[voice2NoteNum++];
-                        int[] psgBytes = note.Encode();
+                        byte[] psgBytes = note.Encode();
                         psg.write(psgBytes[3]);
                         psg.write(psgBytes[2]);
                         psg.write(psgBytes[4]);
@@ -126,7 +126,7 @@ namespace AGILE
                     if (voice3NoteNum < voice3Notes.Count)
                     {
                         Note note = voice3Notes[voice3NoteNum++];
-                        int[] psgBytes = note.Encode();
+                        byte[] psgBytes = note.Encode();
                         psg.write(psgBytes[3]);
                         psg.write(psgBytes[2]);
                         psg.write(psgBytes[4]);
@@ -144,7 +144,7 @@ namespace AGILE
                     if (voice4NoteNum < voice4Notes.Count)
                     {
                         Note note = voice4Notes[voice4NoteNum++];
-                        int[] psgBytes = note.Encode();
+                        byte[] psgBytes = note.Encode();
                         psg.write(psgBytes[3]);
                         psg.write(psgBytes[2]);
                         psg.write(psgBytes[4]);


### PR DESCRIPTION
the update to AGILibrary in commit https://github.com/lanceewing/agile/commit/40dc6112be25c42bd345cdb783bee860b7df8730

caused a compile error.

`Note.Encode()` now returns `byte[]` instead of `int[]`