### PR TITLE
Aspect ratio correction for full screen and window resizing

### DIFF
--- a/AGILE/AgileForm.Designer.cs
+++ b/AGILE/AgileForm.Designer.cs
@@ -77,6 +77,7 @@
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(960, 600);
+            this.BackColor = System.Drawing.SystemColors.Desktop;
             this.ContextMenuStrip = this.cntxtMenu;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.Name = "AgileForm";
@@ -85,6 +86,7 @@
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.AgileForm_Closing);
             this.Load += new System.EventHandler(this.AgileForm_Load);
             this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.AgileForm_KeyDown);
+            this.Resize += new System.EventHandler(this.AgileForm_Resize);
             this.cntxtMenu.ResumeLayout(false);
             this.ResumeLayout(false);
 

--- a/AGILE/AgileForm.Designer.cs
+++ b/AGILE/AgileForm.Designer.cs
@@ -34,6 +34,7 @@
             this.cntxtMenuOpenUserConfig = new System.Windows.Forms.ToolStripMenuItem();
             this.cntxtMenuAspectCorrectionOn = new System.Windows.Forms.ToolStripMenuItem();
             this.cntxtMenuAspectCorrectionOff = new System.Windows.Forms.ToolStripMenuItem();
+            this.cntxtMenuStretchMode = new System.Windows.Forms.ToolStripMenuItem();
             this.cntxtMenu.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -42,9 +43,10 @@
             this.cntxtMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.cntxtMenuOpenUserConfig,
             this.cntxtMenuAspectCorrectionOn,
-            this.cntxtMenuAspectCorrectionOff});
+            this.cntxtMenuAspectCorrectionOff,
+            this.cntxtMenuStretchMode});
             this.cntxtMenu.Name = "cntxtMenu";
-            this.cntxtMenu.Size = new System.Drawing.Size(190, 70);
+            this.cntxtMenu.Size = new System.Drawing.Size(190, 92);
             this.cntxtMenu.Opening += new System.ComponentModel.CancelEventHandler(this.cntxtMenu_Opening);
             // 
             // cntxtMenuOpenUserConfig
@@ -72,6 +74,14 @@
             this.cntxtMenuAspectCorrectionOff.Text = "Aspect Correction Off";
             this.cntxtMenuAspectCorrectionOff.Click += new System.EventHandler(this.cntxtMenuAspectCorrectionOff_Click);
             // 
+            // cntxtMenuStretchMode
+            // 
+            this.cntxtMenuStretchMode.CheckOnClick = true;
+            this.cntxtMenuStretchMode.Name = "cntxtMenuStretchMode";
+            this.cntxtMenuStretchMode.Size = new System.Drawing.Size(189, 22);
+            this.cntxtMenuStretchMode.Text = "Stretch Mode";
+            this.cntxtMenuStretchMode.Click += new System.EventHandler(this.cntxtMenuStretchMode_Click);
+            // 
             // AgileForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -98,6 +108,7 @@
         private System.Windows.Forms.ToolStripMenuItem cntxtMenuOpenUserConfig;
         private System.Windows.Forms.ToolStripMenuItem cntxtMenuAspectCorrectionOn;
         private System.Windows.Forms.ToolStripMenuItem cntxtMenuAspectCorrectionOff;
+        private System.Windows.Forms.ToolStripMenuItem cntxtMenuStretchMode;
     }
 }
 

--- a/AGILE/AgileForm.cs
+++ b/AGILE/AgileForm.cs
@@ -89,20 +89,30 @@ namespace AGILE
         {
             if (this.screen != null)
             {
-                if (cntxtMenuAspectCorrectionOn.Checked)
+                if (cntxtMenuStretchMode.Checked)
                 {
+                    // Stretch mode, so fill the window completely (i.e. stretch to fit).
+                    screen.Location = new Point(0, 0);
+                    screen.Dock = DockStyle.Fill;
+                }
+                else 
+                {
+                    // Aspect correction on uses 4:3, and off uses 8:5.
+                    int ratioWidth = (cntxtMenuAspectCorrectionOn.Checked ? 4 : 8);
+                    int ratioHeight = (cntxtMenuAspectCorrectionOn.Checked ? 3 : 5);
+
                     // Stops GameScreen filling screen (this is mainly to support fullscreen mode)
                     screen.Dock = DockStyle.None;
 
-                    if (ClientSize.Height >= ((ClientSize.Width / 4) * 3))
+                    if (Screen.FromControl(this).Bounds.Height >= ((ClientSize.Width / ratioWidth) * ratioHeight))
                     {
                         // GameScreen fills whole width, adjusting height according to aspect ratio.
-                        screen.Size = new Size(ClientSize.Width, ((ClientSize.Width / 4) * 3));
+                        screen.Size = new Size(ClientSize.Width, ((ClientSize.Width / ratioWidth) * ratioHeight));
                     }
                     else
                     {
                         // GameScreen fills whole height, adjusting width according to aspect ratio.
-                        screen.Size = new Size(((ClientSize.Height / 3) * 4), ClientSize.Height);
+                        screen.Size = new Size(((ClientSize.Height / ratioHeight) * ratioWidth), ClientSize.Height);
                     }
 
                     // Center the GameScreen (this is mainly to support fullscreen mode)
@@ -115,12 +125,6 @@ namespace AGILE
                     {
                         ClientSize = this.screen.Size;
                     }
-                }
-                else
-                {
-                    // No aspect correction, so fill the window completely.
-                    screen.Location = new Point(0, 0);
-                    screen.Dock = DockStyle.Fill;
                 }
             }
         }
@@ -268,10 +272,9 @@ namespace AGILE
         /// <param name="
         private void cntxtMenuAspectCorrectionOn_Click(object sender, EventArgs e)
         {
-            if (cntxtMenuAspectCorrectionOn.Checked == true)
-                cntxtMenuAspectCorrectionOff.Checked = false;
-            else
-                cntxtMenuAspectCorrectionOff.Checked = true;
+            cntxtMenuStretchMode.Checked = false;
+            cntxtMenuAspectCorrectionOff.Checked = false;
+            cntxtMenuAspectCorrectionOn.Checked = true;
 
             AdjustGameScreen();
         }
@@ -283,10 +286,23 @@ namespace AGILE
         /// <param name="e"></param>
         private void cntxtMenuAspectCorrectionOff_Click(object sender, EventArgs e)
         {
-            if (cntxtMenuAspectCorrectionOff.Checked == true)
-                cntxtMenuAspectCorrectionOn.Checked = false;
-            else
-                cntxtMenuAspectCorrectionOn.Checked = true;
+            cntxtMenuStretchMode.Checked = false;
+            cntxtMenuAspectCorrectionOff.Checked = true;
+            cntxtMenuAspectCorrectionOn.Checked = false;
+
+            AdjustGameScreen();
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void cntxtMenuStretchMode_Click(object sender, EventArgs e)
+        {
+            cntxtMenuStretchMode.Checked = true;
+            cntxtMenuAspectCorrectionOff.Checked = false;
+            cntxtMenuAspectCorrectionOn.Checked = false;
 
             AdjustGameScreen();
         }

--- a/AGILE/AnimatedObject.cs
+++ b/AGILE/AnimatedObject.cs
@@ -948,7 +948,8 @@ namespace AGILE
         /// <returns></returns>
         private short EffectiveY()
         {
-            return (FixedPriority ? (short)(state.PriorityBase + Math.Ceiling(((168.0 - state.PriorityBase) / 10.0f) * (Priority - 4)) - 1) : Y);
+            // IMPORTANT: When in fixed priority mode, it uses the "top" of the priority band, not the bottom, i.e. the "start" is the top.
+            return (FixedPriority ? (short)(state.PriorityBase + Math.Ceiling(((168.0 - state.PriorityBase) / 10.0f) * (Priority - 4 - 1))) : Y);
         }
 
         /// <summary>


### PR DESCRIPTION
These changes are mainly to support full screen aspect ratio correction.

In order to achieve this, a new method called AdjustGameScreen has been introduced, which dynamically adjusts the size of the GameScreen PictureBox component so that it has a 4:3 ratio, where either the width or height matches the current window width or height, depending on what fits best into the current window dimensions.

When in aspect ratio correction mode:

- If the form height is greater than the (width/4)*3, then the width of the GameScreen is set to the width of the form and the height of the GameScreen adjusted such that the height is at a 3:4 ratio with the new width.
- Otherwise the height of the GameScreen is set to the height of the form and the width of the GameScreen adjusted such that the width is at a 4:3 ratio with the new height.

This is done regardless of whether the game is in fullscreen mode or not, but the change is primarily to support full screen, since the only way to achieve the desired result in fullscreen is to adjust the GameScreen PictureBox dimensions. It just so happens that the same approach works for the window mode as well.

It works for the window mode because, immediately after adjusting the size of the GameScreen PictureBox, if AGILE is not in full screen mode or maximized mode, then it crops the form size to match the GameScreen size.

It also adjusts the Location of the GameScreen to be centered within the window. This is mainly to support fullscreen mode, since without this, it would not be centered.

To make the above all work, this new AdjustGameScreen method needs to be invoked from a number of different places:

- When aspect correction is enabled.
- When aspect correction is disabled.
- When the form is resized.
- When the form is first loaded.

With all that in place, it all works quite nicely. When in aspect correction mode, resizing the screen maintains the aspect ratio. It also works nicely for switches between fullscreen and not fullscreen, and for maximizing and restoring the window. Switching aspect ratio correction on and off works well within fullscreen mode. All combinations works.

I have changed the saving of the window location and size on application exit to only be done when not in fullscreen mode, as currently that isn't working too well. It seems to save the large screen size in a state that is difficult to resize with the mouse cursor. 

When not in aspect correction mode, the game picture stretches to fill the window, both in full screen and in now full screen.
