### PR TITLE
do not print question mark character if at the beginning

### DIFF
--- a/AGILE/TextGraphics.cs
+++ b/AGILE/TextGraphics.cs
@@ -81,7 +81,6 @@ namespace AGILE
         private int maxLength;
 
         private char escapeChar = '\\';         /* the escape character */
-        private char unknownChar = '\u003f';    /* unknown characters shows up as '?' */
 
         /// <summary>
         /// The GameState class holds all of the data and state for the Game currently 
@@ -695,7 +694,7 @@ namespace AGILE
             maxLength = 0;
 
             if (str != null)
-            {
+            {                
                 // Recursively expand/substitute references to other strings.
                 string processedMessage = ExpandReferences(str);
 
@@ -872,9 +871,9 @@ namespace AGILE
                             break;
                     }
                 }
-                else if (str[i] == unknownChar)
+                else if (i == 0 && str[i] == '?')
                 {
-                    // replace unprintable char to space
+                    // kq2 has some message that starts with a `?`. Replace that with space
                     output.Append(' ');
                 }
                 else

--- a/AGILE/TextGraphics.cs
+++ b/AGILE/TextGraphics.cs
@@ -694,7 +694,7 @@ namespace AGILE
             maxLength = 0;
 
             if (str != null)
-            {                
+            {
                 // Recursively expand/substitute references to other strings.
                 string processedMessage = ExpandReferences(str);
 

--- a/AGILE/TextGraphics.cs
+++ b/AGILE/TextGraphics.cs
@@ -81,6 +81,7 @@ namespace AGILE
         private int maxLength;
 
         private char escapeChar = '\\';         /* the escape character */
+        private char unknownChar = '\u003f';    /* unknown characters shows up as '?' */
 
         /// <summary>
         /// The GameState class holds all of the data and state for the Game currently 
@@ -870,6 +871,11 @@ namespace AGILE
                         default: // ignore the second character.
                             break;
                     }
+                }
+                else if (str[i] == unknownChar)
+                {
+                    // replace unprintable char to space
+                    output.Append(' ');
                 }
                 else
                 {


### PR DESCRIPTION
on KQ2, when you read the sign on the tree, `?` are showing up on the text:

![bugtext](https://user-images.githubusercontent.com/285941/197399531-e1447475-01af-4e1d-9f5f-57bf8f9835ed.PNG)

Extracting the logic (logic 30) using jagi shows this data in the messages:

![messagedata](https://user-images.githubusercontent.com/285941/197399565-f0638fc8-6d95-4ca8-8226-f9a37bfa1c1d.PNG)

Heres the output after fixing:

![fixed](https://user-images.githubusercontent.com/285941/197399584-8e664de1-6e68-4d98-af58-8c85d68daf31.PNG)


For reference where the bug happens:

https://youtu.be/_jjUaeG9YTw?t=131