### PR TITLE
use state.Vars[Defines.CURROOM] when assigning PREVROOM

### DIFF
--- a/AGILE/Interpreter.cs
+++ b/AGILE/Interpreter.cs
@@ -291,7 +291,7 @@ namespace AGILE
             // Change the room number. Note that some games, e.g. MH2, change the CURROOM VAR directly, 
             // which is why we also track the CurrentRoom in a separate state variable. We can't rely
             // on the AGI VAR that stores the current room.
-            state.Vars[Defines.PREVROOM] = state.CurrentRoom;
+            state.Vars[Defines.PREVROOM] = state.Vars[Defines.CURROOM];
             state.Vars[Defines.CURROOM] = state.CurrentRoom = roomNum;
 
             // Set flags and vars as appropriate for a new room.


### PR DESCRIPTION
fixes #13 

there are two variable in `state` which stores the current room

`state.CurrentRoom` and `state.Vars[Defines.CURROOM]`

the Logic files updates `state.Vars[Defines.CURROOM]` which makes `state.CurrentRoom` stale

in the case of the sq2 promo in kq2 in logic 110, the logic does

`vCurrentRoom = v120;` 

which updates  `state.Vars[Defines.CURROOM]` but not  `state.CurrentRoom` which makes the two states inconsistent.



