### PR TITLE
do not clear key to controller mapping on restart

### DIFF
--- a/AGILE/GameState.cs
+++ b/AGILE/GameState.cs
@@ -249,7 +249,9 @@ namespace AGILE
             CurrentInput.Clear();
             LastInput = "";
             SimpleName = "";
-            KeyToControllerMap.Clear();
+            // Do not clear this mapping. There is an issue in KQ1 after restarting the game
+            // the KeyToControllerMap will never be repopulated
+            // KeyToControllerMap.Clear();
             MenuEnabled = true;
             HoldKey = false;
 


### PR DESCRIPTION
Bug:

On kq1, when you restart the game, all the key to controller mapping will be lost (esc, f4, f5, =, etc.)

Reproduce

1. start kq1
2. test controller mapping works (esc, f4, f5, =) 
3. restart game by pressing F9
4. controller mapping doesn't work any more

Looking at the issue

On cold start, kq1 loads logic 0 and calls logic 83   to configure key to controller mapping

on restart (warm start/boot), logic 0 skips calling logic 83 and immediately calls `new.room(Logic1);`

I think its okay not to clear `KeyToControllerMap` dictionary on restart, the `set.key` command is smart enough to replace existing one so other games doesn't break.....

I tested on kq2 and its working as is

https://github.com/lanceewing/agile/blob/master/AGILE/Commands.cs#L1587-L1601