### PR TITLE
add ANYWORD to RecognisedWordNumbers list

### DIFF
--- a/AGILE/Parser.cs
+++ b/AGILE/Parser.cs
@@ -115,8 +115,9 @@ namespace AGILE
                 }
                 else if (!wordToMatch.Equals("a") && !wordToMatch.Equals("i"))
                 {
-                    // Unrecognised word. Stores the word, but not word number. Breaks out on first unrecognised word.
+                    // Unrecognised word. Stores the word, use ANYWORD (word number 1, place holder for any word)
                     state.RecognisedWords.Add(wordToMatch);
+                    this.RecognisedWordNumbers.Add(ANYWORD);
                     state.Vars[Defines.UNKNOWN_WORD] = (byte)(state.RecognisedWords.Count);
                     break;
                 }


### PR DESCRIPTION
we should be storing `ANYWORD` for any unrecognized word in the input.

To reproduce the bug:

1. open KQ2
2. type `get ddddd`

AGILE:

![Capture](https://user-images.githubusercontent.com/285941/199086754-b0d8715a-7b0a-4834-8d7f-04e8c992adae.PNG)


AGI:

![Capture](https://user-images.githubusercontent.com/285941/199086959-4df83f88-cc6c-40f7-871b-b58cffddb992.PNG)
