### PR TITLE
encode object to match original interpreter

### DIFF
--- a/AGILE/SavedGames.cs
+++ b/AGILE/SavedGames.cs
@@ -395,7 +395,7 @@ namespace AGILE
                 }
             }
 
-            // Recreate the raw byte data
+            // Dump of the in memory OBJECT file including updates made by get, put and drop commands
             MemoryStream memoryStream = new MemoryStream();
             memoryStream.WriteByte((byte)((uint)num & 0xFFu));
             memoryStream.WriteByte((byte)((uint)(num >> 8) & 0xFFu));

--- a/AGILE/SavedGames.cs
+++ b/AGILE/SavedGames.cs
@@ -392,7 +392,6 @@ namespace AGILE
                     itemList.Add(agiObject);
                     // 1 = NUL char
                     offset = offset + (agiObject.Name.Length + 1);
-
                 }
             }
 


### PR DESCRIPTION
fixes #18

Write our own encode function instead of using AGILibrary `Encode()`

This function reproduces a 1-to-1 match of the raw data that the original interpreter generates when saving a game

best way to validate is to create a save game from both AGILE and original AGI and compare the OBJECTS section and verify that byte data matches exactly the same.

You can also verify by restoring an AGILE created save game using the original interpreter 