### PR TITLE
allow parser to accept sentences

### DIFF
--- a/AGILE/Parser.cs
+++ b/AGILE/Parser.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 
 namespace AGILE


### PR DESCRIPTION
Some words in the LSL1 are actual sentences. For example, the password for the door in Lefty's bar is "al sent me"

The current parser tokenizes the string and check word for word thus won't accept the sentence "al sent me"

This PR fixes it by checking that entire input line first (after sanitizing it) before tokenizing the input