### PR TITLE
allow restore game to bypass NO_SCRIPT flag

### DIFF
--- a/AGILE/SavedGames.cs
+++ b/AGILE/SavedGames.cs
@@ -1057,7 +1057,7 @@ namespace AGILE
                     // Increase i to account for the fact that we've processed an additional 3 slots.
                     i += 3;
                 }
-                state.ScriptBuffer.AddScript((ScriptBuffer.ScriptBufferEventType)action, resourceNum, data);
+                state.ScriptBuffer.RestoreScript((ScriptBuffer.ScriptBufferEventType)action, resourceNum, data);
             }
 
             // FIFTH PIECE: SCAN OFFSETS

--- a/AGILE/ScriptBuffer.cs
+++ b/AGILE/ScriptBuffer.cs
@@ -174,5 +174,20 @@ namespace AGILE
             // unused part as well.
             return stream.GetBuffer();
         }
+
+        /// <summary>
+        /// Add an event to the script buffer without checking NO_SCRIPT flag. Used primarily by restore save game function.
+        /// </summary>
+        /// <param name="action"></param>
+        /// <param name="who"></param>
+        public void RestoreScript(ScriptBufferEventType action, int who, byte[] data = null)
+        {
+            Events.Add(new ScriptBufferEvent(action, who, data));
+
+            if (Events.Count > MaxScript)
+            {
+                MaxScript = Events.Count;
+            }
+        }
     }
 }


### PR DESCRIPTION
fixes #37 

On restore game, AGI restores the script buffer regardless of what `NO_SCRIPT` flag is set to

in `RESTGAME.C`

```
if (!ReadSave(fd, &saveStart)
		|| !ReadSave(fd, aniObj)
		|| !ReadSave(fd, object)
		|| !ReadSave(fd, script)
		|| !ReadSave(fd, scanOfs))
			{
			close(fd);
			WindowPrint("Error in restoring game.\nPress ENTER to quit.");
			Quit();
			}
```
 in AGILE, the `NO_SCRIPT` flag was set to `true` (see details on linked issue why its `true`) so all calls the `AddScript` during restore game was resulting to a no-op thus the buffer wasn't adding new events.
