### PR TITLE
do not skip any scripts events in the save game file

### DIFF
--- a/AGILE/ScriptBuffer.cs
+++ b/AGILE/ScriptBuffer.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace AGILE
 {
@@ -54,7 +50,28 @@ namespace AGILE
 
         public int MaxScript;
         public int ScriptSize;
-        public int ScriptEntries { get { return Events.Count; } }
+        public int ScriptEntries
+        {
+            get
+            {
+                int count = 0;
+                foreach (ScriptBufferEvent e in Events)
+                {
+                    // in AGI, the add.to.pic script event consist of 4 entries
+                    // (who, action, loop #, view #, X, Y, cel #, priority)
+                    // the rest of the events are just 1 entry (who, action)
+                    if (e.type == ScriptBufferEventType.AddToPic)
+                    {
+                        count += 4;
+                    }
+                    else
+                    {
+                        count += 1;
+                    }
+                }
+                return count;
+            }
+        }
         public int SavedScript;
 
         /// <summary>
@@ -101,11 +118,11 @@ namespace AGILE
         /// <param name="who"></param>
         public void AddScript(ScriptBufferEventType action, int who, byte[] data = null)
         {
-	        if (state.Flags[Defines.NO_SCRIPT]) return;
+            if (state.Flags[Defines.NO_SCRIPT]) return;
 
-	        if (doScript)
+            if (doScript)
             {
-		        if (Events.Count >= this.ScriptSize)
+                if (Events.Count >= this.ScriptSize)
                 {
                     // TODO: Error. Error(11, maxScript);
                     return;
@@ -114,7 +131,7 @@ namespace AGILE
                 {
                     Events.Add(new ScriptBufferEvent(action, who, data));
                 }
-		    }
+            }
 
             if (Events.Count > MaxScript)
             {


### PR DESCRIPTION
fixes #41 issue number 2

I dont know why we are skipping 3 script entries with 

```
// Increase i to account for the fact that we've processed an additional 3 slots.
i += 3;
```

if the script buffer in the save game has 19 events then we should run all 19 events..

In the case of the LSL1 disco room...

there are 19 events... 11 are `add.to.pic` events..... 

See Logic 24:

```
add.to.pic(View94, 0, 0, 115, 120, 11, 0);
  add.to.pic(View94, 0, 1, 24, 132, 0, 0);
  add.to.pic(View94, 0, 2, 24, 159, 0, 0);
  add.to.pic(View94, 0, 3, 105, 108, 4, 4);
  add.to.pic(View94, 0, 4, 49, 158, 0, 0);
  add.to.pic(View94, 0, 5, 98, 108, 4, 4);
  add.to.pic(View94, 1, 1, 24, 112, 12, 4);
  add.to.pic(View94, 1, 2, 24, 139, 14, 4);
  add.to.pic(View94, 1, 3, 105, 89, 4, 4);
  add.to.pic(View94, 1, 4, 49, 138, 14, 4);
  add.to.pic(View94, 1, 5, 98, 90, 4, 4);
```

skipping some events due to the `i += 3;` result in 

![Capture3](https://user-images.githubusercontent.com/285941/199627657-6f14b585-bc6d-4a4b-bf49-7d3a6166277f.PNG)

the `add.to.pic` event has more data.. we just need to increment the offset instead of doing  `i += 3;` 

