### PR TITLE
NSIS installer script tweaks.

### DIFF
--- a/AGILE/AGILE.csproj
+++ b/AGILE/AGILE.csproj
@@ -19,7 +19,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -121,6 +121,11 @@
     <Compile Include="Parser.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Properties\Settings.Designer.cs">
+      <AutoGen>True</AutoGen>
+      <DesignTimeSharedInput>True</DesignTimeSharedInput>
+      <DependentUpon>Settings.settings</DependentUpon>
+    </Compile>
     <Compile Include="SavedGames.cs" />
     <Compile Include="ScriptBuffer.cs" />
     <Compile Include="SoundPlayer.cs" />
@@ -147,11 +152,6 @@
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
     </None>
-    <Compile Include="Properties\Settings.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DependentUpon>Settings.settings</DependentUpon>
-      <DesignTimeSharedInput>True</DesignTimeSharedInput>
-    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/AGILE/AGILE.csproj.user
+++ b/AGILE/AGILE.csproj.user
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <ProjectView>ShowAllFiles</ProjectView>
+    <ProjectView>ProjectFiles</ProjectView>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <StartWorkingDirectory>

--- a/AGILE/AGILE.csproj.user
+++ b/AGILE/AGILE.csproj.user
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <ProjectView>ProjectFiles</ProjectView>
+    <ProjectView>ShowAllFiles</ProjectView>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <StartWorkingDirectory>

--- a/AGILE/AgileForm.Designer.cs
+++ b/AGILE/AgileForm.Designer.cs
@@ -32,11 +32,11 @@ namespace AGILE
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(AgileForm));
             this.cntxtMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.cntxtMenuOpenUserConfig = new System.Windows.Forms.ToolStripMenuItem();
+            this.cntxtMenuOptions = new System.Windows.Forms.ToolStripMenuItem();
             this.cntxtMenuFullScreen = new System.Windows.Forms.ToolStripMenuItem();
             this.cntxtMenuAspectCorrectionOn = new System.Windows.Forms.ToolStripMenuItem();
             this.cntxtMenuAspectCorrectionOff = new System.Windows.Forms.ToolStripMenuItem();
             this.cntxtMenuStretchMode = new System.Windows.Forms.ToolStripMenuItem();
-            this.cntxtMenuOptions = new System.Windows.Forms.ToolStripMenuItem();
             this.cntxtMenu.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -50,7 +50,7 @@ namespace AGILE
             this.cntxtMenuAspectCorrectionOff,
             this.cntxtMenuStretchMode});
             this.cntxtMenu.Name = "cntxtMenu";
-            this.cntxtMenu.Size = new System.Drawing.Size(190, 158);
+            this.cntxtMenu.Size = new System.Drawing.Size(190, 136);
             this.cntxtMenu.Opening += new System.ComponentModel.CancelEventHandler(this.cntxtMenu_Opening);
             // 
             // cntxtMenuOpenUserConfig

--- a/AGILE/App.config
+++ b/AGILE/App.config
@@ -20,7 +20,7 @@
                         <value>0, 0</value>
                 </setting>
                 <setting name="useSystemXMLDefault" serializeAs="String">
-                        <value>False</value>
+                        <value>True</value>
                 </setting>
                 <setting name="xmlEditor" serializeAs="String">
                         <value />

--- a/AGILE/OptionsFrm.Designer.cs
+++ b/AGILE/OptionsFrm.Designer.cs
@@ -99,6 +99,8 @@ namespace AGILE
             // systemXMLDefaultChkBox
             // 
             this.systemXMLDefaultChkBox.AutoSize = true;
+            this.systemXMLDefaultChkBox.Checked = true;
+            this.systemXMLDefaultChkBox.CheckState = System.Windows.Forms.CheckState.Checked;
             this.systemXMLDefaultChkBox.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.systemXMLDefaultChkBox.Location = new System.Drawing.Point(6, 50);
             this.systemXMLDefaultChkBox.Name = "systemXMLDefaultChkBox";
@@ -125,7 +127,7 @@ namespace AGILE
             this.textBox1.Size = new System.Drawing.Size(348, 48);
             this.textBox1.TabIndex = 1000;
             this.textBox1.TabStop = false;
-            this.textBox1.Text = "Select external XML editor for manually editing save files.";
+            this.textBox1.Text = "Select external XML editor for viewing your user config file.";
             // 
             // browseXMLEditorBtn
             // 

--- a/AGILE/OptionsFrm.Designer.cs
+++ b/AGILE/OptionsFrm.Designer.cs
@@ -127,7 +127,7 @@ namespace AGILE
             this.textBox1.Size = new System.Drawing.Size(348, 48);
             this.textBox1.TabIndex = 1000;
             this.textBox1.TabStop = false;
-            this.textBox1.Text = "Select external XML editor for viewing your user config file.";
+            this.textBox1.Text = "Select external XML editor for viewing your user AGILE config file.";
             // 
             // browseXMLEditorBtn
             // 

--- a/AGILE/OptionsFrm.cs
+++ b/AGILE/OptionsFrm.cs
@@ -3,6 +3,7 @@ using System.Windows.Forms;
 using System.IO;
 using Microsoft.Win32;
 using System.Reflection;
+using AGILE.Properties;
 
 namespace AGILE
 {
@@ -17,6 +18,7 @@ namespace AGILE
         //public static string assemblyPath = Path.GetDirectoryName(assemblyEXE).Replace("%20", " ");
         //public static string assemblyEXEName = Path.GetFileName(assemblyPath);
 
+        public static bool? useSystemXMLDefault = Properties.Settings.Default.useSystemXMLDefault;
         private static string xmlEditor = Properties.Settings.Default.xmlEditor;
         private static string currentXMLEditor = null;
         public static bool nullXML = false;
@@ -51,16 +53,23 @@ namespace AGILE
 
             #endregion Load Screen Metrics
 
-            systemXMLDefaultChkBox.Checked = Properties.Settings.Default.useSystemXMLDefault;
-
+            // Populate controls
             currentXMLEditor = Properties.Settings.Default.xmlEditor;
 
-            // Populate controls
-            if (File.Exists(Properties.Settings.Default.xmlEditor))
+            // Get if default XML editor is to be used
+            if (useSystemXMLDefault.HasValue)
+            {
+                systemXMLDefaultChkBox.Checked = Properties.Settings.Default.useSystemXMLDefault;
+                systemXMLDefaultChkBox_CheckedChanged(null, null);
+            }
+            else if (File.Exists(Properties.Settings.Default.xmlEditor))
             {
                 xmlEditor = Properties.Settings.Default.xmlEditor;
                 xmlEditorTxtBox.Text = xmlEditor;
             }
+
+            // Deselect text in xmlEditorTxtBox
+            xmlEditorTxtBox.Select(0, 0);
 
             // Get status of directory shellex 
             RegistryKey rkSubKey = Registry.ClassesRoot.OpenSubKey("Directory\\shell\\AGILE", false);
@@ -68,8 +77,6 @@ namespace AGILE
                 runInAgileChkBox.Checked = false;
             else
                 runInAgileChkBox.Checked = true;
-
-            xmlEditorTxtBox.Select(0, 0); ;
         }
 
         /// <summary>
@@ -98,6 +105,9 @@ namespace AGILE
         /// <param name="e"></param>
         private void systemXMLDefaultChkBox_CheckedChanged(object sender, EventArgs e)
         {
+            xmlEditorTxtBox.Enabled = !systemXMLDefaultChkBox.Checked;
+            browseXMLEditorBtn.Enabled = !systemXMLDefaultChkBox.Checked;
+
             try
             {
                 using (RegistryKey key = Registry.ClassesRoot.OpenSubKey("xmlfile\\shell\\open\\command"))

--- a/AGILE/Properties/Settings.Designer.cs
+++ b/AGILE/Properties/Settings.Designer.cs
@@ -61,7 +61,7 @@ namespace AGILE.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
         public bool useSystemXMLDefault {
             get {
                 return ((bool)(this["useSystemXMLDefault"]));

--- a/AGILE/Properties/Settings.settings
+++ b/AGILE/Properties/Settings.settings
@@ -12,7 +12,7 @@
       <Value Profile="(Default)">0, 0</Value>
     </Setting>
     <Setting Name="useSystemXMLDefault" Type="System.Boolean" Scope="User">
-      <Value Profile="(Default)">False</Value>
+      <Value Profile="(Default)">True</Value>
     </Setting>
     <Setting Name="xmlEditor" Type="System.String" Scope="User">
       <Value Profile="(Default)" />

--- a/NSIS-Installer/AGILE.nsi
+++ b/NSIS-Installer/AGILE.nsi
@@ -17,7 +17,7 @@
 !define PRODUCT_FILE_NAME "AGILE" ; PRODUCT_NAME without Illegal File Name Characters
 !define SHORT_NAME "AGILE" ; Common abbreviated app name
 !define DOS_NAME "AGILE" ; Name to Conform to 8.3 Naming Convention
-!define RESOURCE_NAME "Misc\AGILE" ; Name of Folder for Resource Files
+!define RESOURCE_NAME "" ; Path to folder for resource files
 
 ; Add uninstaller info
 !define PRODUCT_DIR_REGKEY "Software\Microsoft\Windows\CurrentVersion\App Paths\AGILE.exe"

--- a/NSIS-Installer/AGILE.nsi
+++ b/NSIS-Installer/AGILE.nsi
@@ -1,8 +1,8 @@
 ; Generic NSIS Installer Script
 ; Template by Andrew Branscom (Collector)
 ; Script by Andrew Branscom
-; Set "!define RESOURCE_NAME" to your own path (can be the app's build folder)
-; Add GPL.TXT and "README.md" renamed to "README.TXT" to files resource path ( ${RESOURCE_NAME} )
+; Set "!define RESOURCEPATH" to your own path (can be the app's build folder)
+; Add GPL.TXT and "README.md" renamed to "README.TXT" to files resource path ( ${RESOURCEPATH} )
 
 ; Header ------------------------------------------------------
 
@@ -17,7 +17,7 @@
 !define PRODUCT_FILE_NAME "AGILE" ; PRODUCT_NAME without Illegal File Name Characters
 !define SHORT_NAME "AGILE" ; Common abbreviated app name
 !define DOS_NAME "AGILE" ; Name to Conform to 8.3 Naming Convention
-!define RESOURCE_NAME "" ; Path to folder for resource files
+!define RESOURCEPATH "..\AGILE\bin\Debug" ; Path to folder for resource files
 
 ; Add uninstaller info
 !define PRODUCT_DIR_REGKEY "Software\Microsoft\Windows\CurrentVersion\App Paths\AGILE.exe"
@@ -41,12 +41,12 @@ SetCompressor /solid lzma
 
 ; Pages -------------------------------------------------------
 ; Welcome page
-!define MUI_WELCOMEFINISHPAGE_BITMAP "${RESOURCE_PATH}\${DOS_NAME}.bmp"
+!define MUI_WELCOMEFINISHPAGE_BITMAP "${RESOURCEPATH}\${DOS_NAME}.bmp"
 !define MUI_WELCOMEPAGE_TITLE_3LINES!insertmacro MUI_PAGE_WELCOME
 
 ; License page
 !define MUI_LICENSEPAGE_BGCOLOR /gray
-!insertmacro MUI_PAGE_LICENSE "${RESOURCE_PATH}\GPL.TXT" ; "${ReadmeFile}"
+!insertmacro MUI_PAGE_LICENSE "${RESOURCEPATH}\GPL.TXT" ; "${ReadmeFile}"
 
 ; Options page
 !define MUI_PAGE_CUSTOMFUNCTION_PRE OptionsPre
@@ -95,13 +95,13 @@ var ICONS_GROUP
   VIAddVersionKey /LANG=${LANG_ENGLISH} "Comments" "${PRODUCT_NAME} installer"
   VIAddVersionKey /LANG=${LANG_ENGLISH} "CompanyName" "${PRODUCT_PUBLISHER}"
   VIAddVersionKey /LANG=${LANG_ENGLISH} "LegalTrademarks" "${PUBLISHER_ACRONYM} is a trademark of ${PRODUCT_PUBLISHER}"
-  VIAddVersionKey /LANG=${LANG_ENGLISH} "LegalCopyright" "© ${PRODUCT_PUBLISHER}"
+  VIAddVersionKey /LANG=${LANG_ENGLISH} "LegalCopyright" "Â© ${PRODUCT_PUBLISHER}"
   VIAddVersionKey /LANG=${LANG_ENGLISH} "FileDescription" "AGILE installer."
   VIAddVersionKey /LANG=${LANG_ENGLISH} "FileVersion" "1.0.0"
 ;--------------------------------------------------------------
 
 Name "${PRODUCT_NAME} ${PRODUCT_VERSION}"
-OutFile "${BASE_PATH}\${DOS_NAME}Setup.exe"
+OutFile "${RESOURCEPATH}\${DOS_NAME}Setup.exe"
 InstallDir "$PROGRAMFILES\${PRODUCT_FILE_NAME}"
 InstallDirRegKey HKLM "${PRODUCT_DIR_RegKey}" ""
 ShowInstDetails show
@@ -123,20 +123,20 @@ Section "${PRODUCT_NAME}" SEC01 ;MainSection
   SetOutPath "$INSTDIR"
   
   ; Add Resource Files ----------------------------------------
-  File "${RESOURCE_PATH}\GPL.TXT"
-  File "${RESOURCE_PATH}\README.TXT"
+  File "${RESOURCEPATH}\GPL.TXT"
+  File "${RESOURCEPATH}\README.TXT"
   
   ; Copy Game Files -------------------------------------------
   SetOutPath "$INSTDIR"
-  File "${RESOURCE_PATH}\AGILibrary.dll"
-  File "${RESOURCE_PATH}\NAudio.Asio.dll"
-  File "${RESOURCE_PATH}\NAudio.Core.dll"
-  File "${RESOURCE_PATH}\NAudio.dll"
-  File "${RESOURCE_PATH}\NAudio.Midi.dll"
-  File "${RESOURCE_PATH}\NAudio.Wasapi.dll"
-  File "${RESOURCE_PATH}\NAudio.WinForms.dll"
-  File "${RESOURCE_PATH}\NAudio.WinMM.dll"
-  File "${RESOURCE_PATH}\AGILE.exe"
+  File "${RESOURCEPATH}\AGILibrary.dll"
+  File "${RESOURCEPATH}\NAudio.Asio.dll"
+  File "${RESOURCEPATH}\NAudio.Core.dll"
+  File "${RESOURCEPATH}\NAudio.dll"
+  File "${RESOURCEPATH}\NAudio.Midi.dll"
+  File "${RESOURCEPATH}\NAudio.Wasapi.dll"
+  File "${RESOURCEPATH}\NAudio.WinForms.dll"
+  File "${RESOURCEPATH}\NAudio.WinMM.dll"
+  File "${RESOURCEPATH}\AGILE.exe"
   
   ; Add Folder ShellEx
   ${If} $AddShellEx == "1"
@@ -151,7 +151,6 @@ Section "${PRODUCT_NAME}" SEC01 ;MainSection
   !insertmacro MUI_STARTMENU_WRITE_BEGIN Application
   CreateDirectory "$SMPROGRAMS\$ICONS_GROUP"
   SetOutPath "$INSTDIR"
-    MessageBox MB_OK `$AddShortcut`
   
   ${If} $AddShortcut == "1"
     CreateShortCut "$DESKTOP\${PRODUCT_FILE_NAME}.lnk" "$INSTDIR\AGILE.exe" "" "" "" "" "" "Run ${PRODUCT_NAME}"

--- a/NSIS-Installer/AGILE.nsi
+++ b/NSIS-Installer/AGILE.nsi
@@ -9,7 +9,7 @@
 ; Defines -----------------------------------------------------
 ; Names
 !define PRODUCT_NAME "AGILE" ; Installer Name
-!define PRODUCT_VERSION "1.1.25" ; Script version of installer
+!define PRODUCT_VERSION "1.0.0" ; Script version of installer
 !define PRODUCT_PUBLISHER "The Sierra Help Pages" ; Installer Publisher
 !define PRODUCT_DEVELOPER "Lance Ewing" ;Installer Developer
 !define PUBLISHER_ACRONYM "SHP" ; Installer Publisher

--- a/NSIS-Installer/AGILE.nsi
+++ b/NSIS-Installer/AGILE.nsi
@@ -18,7 +18,7 @@
 !define SHORT_NAME "AGILE" ; Common abbreviated app name
 !define DOS_NAME "AGILE" ; Name to Conform to 8.3 Naming Convention
 !define RESOURCEPATH "..\AGILE\bin\Debug" ; Path to folder for resource files
-
+""
 ; Add uninstaller info
 !define PRODUCT_DIR_REGKEY "Software\Microsoft\Windows\CurrentVersion\App Paths\AGILE.exe"
 !define PRODUCT_UNINST_KEY "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_NAME}"
@@ -41,12 +41,12 @@ SetCompressor /solid lzma
 
 ; Pages -------------------------------------------------------
 ; Welcome page
-!define MUI_WELCOMEFINISHPAGE_BITMAP "${RESOURCEPATH}\${DOS_NAME}.bmp"
+!define MUI_WELCOMEFINISHPAGE_BITMAP "${DOS_NAME}.bmp"
 !define MUI_WELCOMEPAGE_TITLE_3LINES!insertmacro MUI_PAGE_WELCOME
 
 ; License page
 !define MUI_LICENSEPAGE_BGCOLOR /gray
-!insertmacro MUI_PAGE_LICENSE "${RESOURCEPATH}\GPL.TXT" ; "${ReadmeFile}"
+!insertmacro MUI_PAGE_LICENSE "GPL.TXT" ; "${ReadmeFile}"
 
 ; Options page
 !define MUI_PAGE_CUSTOMFUNCTION_PRE OptionsPre
@@ -95,7 +95,7 @@ var ICONS_GROUP
   VIAddVersionKey /LANG=${LANG_ENGLISH} "Comments" "${PRODUCT_NAME} installer"
   VIAddVersionKey /LANG=${LANG_ENGLISH} "CompanyName" "${PRODUCT_PUBLISHER}"
   VIAddVersionKey /LANG=${LANG_ENGLISH} "LegalTrademarks" "${PUBLISHER_ACRONYM} is a trademark of ${PRODUCT_PUBLISHER}"
-  VIAddVersionKey /LANG=${LANG_ENGLISH} "LegalCopyright" "© ${PRODUCT_PUBLISHER}"
+  VIAddVersionKey /LANG=${LANG_ENGLISH} "LegalCopyright" "Â© ${PRODUCT_PUBLISHER}"
   VIAddVersionKey /LANG=${LANG_ENGLISH} "FileDescription" "AGILE installer."
   VIAddVersionKey /LANG=${LANG_ENGLISH} "FileVersion" "1.0.0"
 ;--------------------------------------------------------------
@@ -123,8 +123,8 @@ Section "${PRODUCT_NAME}" SEC01 ;MainSection
   SetOutPath "$INSTDIR"
   
   ; Add Resource Files ----------------------------------------
-  File "${RESOURCEPATH}\GPL.TXT"
-  File "${RESOURCEPATH}\README.TXT"
+  File "GPL.TXT"
+  File "README.TXT"
   
   ; Copy Game Files -------------------------------------------
   SetOutPath "$INSTDIR"

--- a/NSIS-Installer/AGILE.nsi
+++ b/NSIS-Installer/AGILE.nsi
@@ -18,7 +18,7 @@
 !define SHORT_NAME "AGILE" ; Common abbreviated app name
 !define DOS_NAME "AGILE" ; Name to Conform to 8.3 Naming Convention
 !define RESOURCEPATH "..\AGILE\bin\Debug" ; Path to folder for resource files
-""
+
 ; Add uninstaller info
 !define PRODUCT_DIR_REGKEY "Software\Microsoft\Windows\CurrentVersion\App Paths\AGILE.exe"
 !define PRODUCT_UNINST_KEY "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_NAME}"

--- a/NSIS-Installer/GPL.TXT
+++ b/NSIS-Installer/GPL.TXT
@@ -1,0 +1,340 @@
+		    GNU GENERAL PUBLIC LICENSE
+		       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.
+                       51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+			    Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Library General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+		    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+			    NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+		     END OF TERMS AND CONDITIONS
+
+	    How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Library General
+Public License instead of this License.

--- a/NSIS-Installer/README.TXT
+++ b/NSIS-Installer/README.TXT
@@ -1,0 +1,42 @@
+# AGILE
+
+AGILE is an AGI engine written in C#. AGI was the name of the adventure game interpreter used by Sierra On-Line to run the 3D animated adventure games that they released in the 1980s, which included games such as King's Quest 1/2/3/4, Space Quest 1/2, Police Quest, Leisure Suit Larry, Manhunter 1/2, Gold Rush, Donald Duck's Playground, Black Cauldron, and Mixed-Up Mother Goose.
+
+AGILE is an almost complete implementation that has attempted to align as close as possible to the original interpreter's behaviour.
+
+## Features
+
+- Supports PC AGI v2 & v3 games.
+- IBM PCJR 4-channel sound, using SN76496 emulation.
+- Game detection of most known versions of Sierra's original PC AGI games, and most AGI fan games.
+- Command line parameter to integrate with WinAGI.
+
+## Requirements
+
+- .NET Framework 4.8
+- Windows 7 or later, 32 bit or 64 bit
+
+## How to run
+
+AGILE starts by looking for a command line parameter. If there is a single command line parameter provided, it will use its value as the directory in which to look for the AGI game to run. If the command line parameter is not provided, then it looks in the current working directory. If it isn't able to find an AGI game in that directory, then it will open a Folder Browser Dialog for you to choose the folder that contains the AGI game.
+
+## Screenshots
+
+![](img/kings_quest_1.png)           |  ![](img/kings_quest_2.png)
+:-------------------------:|:-------------------------:
+![](img/kings_quest_3.png)  |  ![](img/kings_quest_4.png)
+![](img/space_quest_1.png)     |  ![](img/space_quest_2.png)
+![](img/manhunter_new_york.png)     |  ![](img/manhunter_san_francisco.png)
+![](img/mixed_up_mother_goose.png)     |  ![](img/donald_ducks_playground.png)
+![](img/gold_rush.png)     |  ![](img/police_quest.png)
+![](img/black_cauldron.png)     |  ![](img/ruby_cast.png)
+
+## Credits 
+
+All the source code for the AGILE interpreter itself, as included in this github repo, is written by me (Lance Ewing).
+
+AGILE makes use of an AGILibrary written by various authors, including me, but as the original repo for that is currently private and not mine, the AGILE repo here includes only the compiled DLL for that library. The AGILibrary was originally from the Visual AGI project, which means it began life with Joakim Möller and Gustaf Wennerholm. Others to work on it since then are Andrew Branscom and Jeremiah Nellis. When AGILE began its life in December 2016, the AGILibrary didn't have support for the LOGIC or SOUND resource types, so part of my work included adding support to decode those resource types to the AGILibrary.
+
+## History
+
+Back in the late 1990s, I wrote an AGI interpreter in C called MEKA. This interpreter was nearly complete but was a bit buggy. The functionality of MEKA was based primarily on the AGI specifications that I had helped create, which were based on reverse engineered info. Since then, large portions of Sierra's original AGI interpreter source code have been discovered, in the unused sectors of the original game disks bought by Sierra's customers (SQ2 v2.0D 720K disks). This has shed some light on the inner workings of the interpreter. AGILE has made use of the MEKA source, the AGI specifications, and the original AGI interpreter source code fragments to create something close to accurate.


### PR DESCRIPTION
Paths should now work without editing script if script remains in its project folder. Just install NSIS and drop my header file in the NSIS Include folder.