### PR TITLE
fix restore bug

### DIFF
--- a/AGILE/Commands.cs
+++ b/AGILE/Commands.cs
@@ -1639,7 +1639,8 @@ namespace AGILE
                             ShowPicture(false);
                             newRoom = state.CurrentRoom = state.Vars[Defines.CURROOM];
                             textGraphics.UpdateStatusLine();
-                            exit = true;
+                            // return 0 so we can start executing the beginning of Logic 0
+                            return 0;                            
                         }
                     }
                     break;

--- a/AGILE/Interpreter.cs
+++ b/AGILE/Interpreter.cs
@@ -1,10 +1,6 @@
 ﻿using AGI;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using System.Diagnostics;
 using System.Threading;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 using static AGI.Resource;
 
@@ -176,8 +172,18 @@ namespace AGILE
                 byte previousScore = state.Vars[Defines.SCORE];
                 bool soundStatus = state.Flags[Defines.SOUNDON];
 
-                // Continue scanning LOGIC 0 while the return value is above 0, indicating a room change.
-                while (NewRoom(commands.ExecuteLogic(0))) ;
+                // Continue scanning LOGIC 0 while NewRoom() return value is true, indicating a room change.
+                bool executeLogicLoop = true;
+                while (executeLogicLoop)
+                {
+                    executeLogicLoop = NewRoom(commands.ExecuteLogic(0));
+                    state.Vars[Defines.OBJHIT] = 0;
+                    state.Vars[Defines.OBJEDGE] = 0;
+                    state.Vars[Defines.UNKNOWN_WORD] = 0;
+                    state.Flags[Defines.INPUT] = false;
+                    previousScore = state.Vars[Defines.SCORE];
+                }
+
 
                 // Set ego's direction from the variable.
                 ego.Direction = state.Vars[Defines.EGODIR];


### PR DESCRIPTION
fixes #45 

I believe this will fix the restore bug in LSL and PQ

Fixes involves
1. Do not exit the LOGIC evaluating loop when restoring game as discussed here:

https://github.com/lanceewing/agile/issues/45#issuecomment-1304645654

2. the `restore.game` command should also `return 0` so LOGIC 0 can be evaluated in the beginning (this fixes the PQ1 bug) where the restore game logic is at the beginning of LOGIC 0

3. Matches also the logic in the `while-loop` and evaluating new room to match the original code. In `MAIN.C`:

```
while (_CallLogic(0) == NULL) {
			var[OBJHIT] = var[OBJEDGE] = var[UNKNOWN_WORD] = 0;
			Reset(INPUT);
			previousScore = var[SCORE];
			}
```

This also fixes the PQ1 bug because in the current code this evaluates to `true` `(state.Vars[Defines.SCORE] != previousScore)`

```
// Update the status line, if the score or sound status have changed.
                if ((state.Vars[Defines.SCORE] != previousScore) || (soundStatus != state.Flags[Defines.SOUNDON]))
                {
                    // If the SOUND ON flag is off, then immediately stop any currently playing sound.
                    if (!state.Flags[Defines.SOUNDON]) soundPlayer.StopSound();

                    textGraphics.UpdateStatusLine();
                }
```

and overrides the status line and remove the map coordinate

