### PR TITLE
Refactored how NewRoom, restore and restart operate

### DIFF
--- a/AGILE/Commands.cs
+++ b/AGILE/Commands.cs
@@ -1620,7 +1620,6 @@ namespace AGILE
                             menu.EnableAllMenus();
                             ReplayScriptEvents();
                             ShowPicture(false);
-                            state.CurrentRoom = state.Vars[Defines.CURROOM];
                             textGraphics.UpdateStatusLine();
                             return 0;
                         }
@@ -2153,11 +2152,9 @@ namespace AGILE
                     break;
             }
 
-            // Change the room number. Note that some games, e.g. MH2, change the CURROOM VAR directly, 
-            // which is why we also track the CurrentRoom in a separate state variable. We can't rely
-            // on the AGI VAR that stores the current room.
+            // Change the room number.
             state.Vars[Defines.PREVROOM] = state.Vars[Defines.CURROOM];
-            state.Vars[Defines.CURROOM] = state.CurrentRoom = roomNum;
+            state.Vars[Defines.CURROOM] = roomNum;
 
             // Set flags and vars as appropriate for a new room.
             state.Vars[Defines.OBJHIT] = 0;

--- a/AGILE/GameState.cs
+++ b/AGILE/GameState.cs
@@ -120,7 +120,6 @@ namespace AGILE
         public int MaxDrawn { get; set; }
         public int PriorityBase { get; set; }
         public string SimpleName { get; set; }
-        public byte CurrentRoom { get; set; }
         public bool MenuEnabled { get; set; }
         public bool MenuOpen { get; set; }
         public bool HoldKey { get; set; }

--- a/AGILE/Interpreter.cs
+++ b/AGILE/Interpreter.cs
@@ -169,7 +169,7 @@ namespace AGILE
                 byte previousScore = state.Vars[Defines.SCORE];
                 bool soundStatus = state.Flags[Defines.SOUNDON];
 
-                // Continue scanning LOGIC 0 while the return value is above 0, indicating a room change.
+                // Continue scanning LOGIC 0 while the return value is true (which is what indicates a rescan).
                 while (commands.ExecuteLogic(0))
                 {
                     state.Vars[Defines.OBJHIT] = 0;


### PR DESCRIPTION
Refactored how NewRoom, restore and restart operate. They should all immediately rescan logics from the top of Logic.0.

This is discussed in PR #48 and issue #45.

As mentioned in some of the comments in those discussions, NewRoom shouldn't have been outside of the main logic execution, as that necessitated a design that made it difficult for restore and restart to also rescan logics. Now that NewRoom is executed at the point where the new.room and new.room.v commands are encountered, then it means the return value for ExecuteLogic can work more like the original AGI interpreter.
