### PR TITLE
Keep priority pixel 0, 1, 2

### DIFF
--- a/AGILE/AnimatedObject.cs
+++ b/AGILE/AnimatedObject.cs
@@ -1476,7 +1476,11 @@ namespace AGILE
                             if (colourIndex != transIndex)
                             {
                                 visualPixels[screenPos] = colourIndex;
-                                priorityPixels[screenPos] = this.Priority;
+                                //  Replace the priority pixel only if the existing one is not a special priority pixel (0, 1, 2)
+                                if (priorityIndex > 2)
+                                {
+                                    priorityPixels[screenPos] = this.Priority;
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
in PQ, Ego can pass thru walls!

![Capture](https://user-images.githubusercontent.com/285941/201235882-a11766bc-e0ac-4ee2-af7a-abd4b5a6cd22.PNG)

In room 49, when the phone (View 90, loop 1, cel 2, priority 12) is drawn on the desk (the middle one), the existing priority pixel 0 gets overridden with the priority pixel of the View (priority 12). 


The picture on the left is AGILE, with all the Views drawn. The picture on the right is the Picture data in WinAGI. You can see the black line (priority 0) behind the desk gets replaced with Priority 12 (light red) when the phone is drawn. Thus Ego walk thru the wall

![Capture2](https://user-images.githubusercontent.com/285941/201236197-fddd368b-1ced-433c-ac5c-8351b3f94faf.PNG)

After the fix:

The priority pixel 0 is preserved after drawing the phone

![Capture3](https://user-images.githubusercontent.com/285941/201236511-c29b7b55-d362-40df-98e4-fef045f7f907.PNG)

[PQSG.zip](https://github.com/lanceewing/agile/files/9985550/PQSG.zip)

Use the attached save game.... just walk north and see Ego pass thru the wall
