### PR TITLE
fix overlay pic command in the script buffer

### DIFF
--- a/AGILE/AgileForm.cs
+++ b/AGILE/AgileForm.cs
@@ -29,8 +29,6 @@ namespace AGILE
         private Boolean fullScreen = false;
         private FormWindowState windowStateBeforeFullscreen;
 
-        private static bool nullXML = false;
-
         private static string xmlEditor = Properties.Settings.Default.xmlEditor;
 
         /// <summary>

--- a/AGILE/Commands.cs
+++ b/AGILE/Commands.cs
@@ -117,7 +117,6 @@ namespace AGILE
             Picture picture = state.CurrentPicture;
 
             Bitmap visualBitmap = picture.Screen.VisualBitmap;
-            Bitmap priorityBitmap = picture.Screen.PriorityBitmap;
 
             // Copy visual pixels to a 160x168 byte array.
             BitmapData visualBitmapData = visualBitmap.LockBits(new Rectangle(0, 0, visualBitmap.Width, visualBitmap.Height), ImageLockMode.ReadWrite, visualBitmap.PixelFormat);

--- a/AGILE/Commands.cs
+++ b/AGILE/Commands.cs
@@ -394,8 +394,7 @@ namespace AGILE
 
                     case ScriptBufferEventType.OverlayPic:
                         {
-                            Picture overlayPicture = state.Pictures[scriptBufferEvent.resourceNumber];
-                            state.CurrentPicture.Screen.DrawCommands(overlayPicture.CommandStack);
+                            OverlayPicture(scriptBufferEvent.resourceNumber);
                         }
                         break;
                 }


### PR DESCRIPTION
in kq1, 

1. Plant the bean stalk. 
2. save game. 
3. restore game.
4. the bean stalk doesn't show up
5. move to a different room
6. go back to the bean stalk room
7. It now shows up

see video of the bug:


https://user-images.githubusercontent.com/285941/201479023-1e280054-dc14-4376-9e95-ea1cea5fa36c.mp4

the `OverlayPic` in the script buffer draws/overlay the pic to the view but doesn't actually render the updated pic.

just calling `OverlayPicture(scriptBufferEvent.resourceNumber);` should fix the issue


Also cleanup code

- fixed warning `The field 'AgileForm.nullXML' is assigned but its value is never used`
- delete unused `priorityBitmap` variable