### PR TITLE
skip lsl1 adult verification questions

### DIFF
--- a/AGILE/AgileForm.cs
+++ b/AGILE/AgileForm.cs
@@ -155,6 +155,7 @@ namespace AGILE
                                     // Verify it's the print function
                                     if (printAction.Operation.Opcode == 101)
                                     {
+                                        // Go to next command in the logic, which is the new.room command
                                         actions[printIndex] = new GotoAction(new List<Operand>() { new Operand(OperandType.ADDRESS, actions[printIndex + 1].Address) });
                                         actions[printIndex].Logic = logic;
                                     }

--- a/AGILE/AgileForm.cs
+++ b/AGILE/AgileForm.cs
@@ -140,12 +140,24 @@ namespace AGILE
                             if (resource.Index == 6)
                             {
                                 // Modifies LOGIC.6 to jump to the code that is run when all of the trivia questions has been answered correctly.
-                                Resource.Logic.Action action = actions[0];
+                                Resource.Logic.Action action = actions[0];                                
                                 // Verify that the action is the if-condition to check if the user can enter the game.
                                 if (action.Operation.Opcode == 255 && action.Operands.Count == 2)
                                 {
                                     actions[0] = new GotoAction(new List<Operand>() { new Operand(OperandType.ADDRESS, actions[1].Address) });
                                     actions[0].Logic = logic;
+
+                                    // Skips the 'Thank you. And now, slip into your leisure suit and prepare to enter the
+                                    // "Land of the Lounge Lizards" with "Leisure "Suit Larry!"' message
+                                    int printIndex = 9;
+                                    Resource.Logic.Action printAction = actions[printIndex];
+
+                                    // Verify it's the print function
+                                    if (printAction.Operation.Opcode == 101)
+                                    {
+                                        actions[printIndex] = new GotoAction(new List<Operand>() { new Operand(OperandType.ADDRESS, actions[printIndex + 1].Address) });
+                                        actions[printIndex].Logic = logic;
+                                    }
                                 }                               
                             }
                             break;

--- a/AGILE/AgileForm.cs
+++ b/AGILE/AgileForm.cs
@@ -137,7 +137,17 @@ namespace AGILE
                             break;
 
                         case "lsl1":
-
+                            if (resource.Index == 6)
+                            {
+                                // Modifies LOGIC.6 to jump to the code that is run when all of the trivia questions has been answered correctly.
+                                Resource.Logic.Action action = actions[0];
+                                // Verify that the action is the if-condition to check if the user can enter the game.
+                                if (action.Operation.Opcode == 255 && action.Operands.Count == 2)
+                                {
+                                    actions[0] = new GotoAction(new List<Operand>() { new Operand(OperandType.ADDRESS, actions[1].Address) });
+                                    actions[0].Logic = logic;
+                                }                               
+                            }
                             break;
 
                         default:


### PR DESCRIPTION
Patches LSL1 to skip adult verification questions

I had to modify Logic 6 (quiz room) and make the if-condition pretend to be `true`

I tried modifying Logic0  and replace Logic6 to Logic 11, but that broke menu item (menu item wont respond)

https://user-images.githubusercontent.com/285941/201548657-150ad2b3-a64a-4a5a-a169-84bd0bd10768.mp4

