### PR TITLE
Patch game option

### DIFF
--- a/AGILE/AgileForm.cs
+++ b/AGILE/AgileForm.cs
@@ -72,8 +72,13 @@ namespace AGILE
             Version appVersion = System.Reflection.Assembly.GetExecutingAssembly().GetName().Version;
             this.Text = $"AGILE v{appVersion.Major}.{appVersion.Minor}.{appVersion.Build}.{appVersion.Revision} | {gameDetection.GameName}";
 
-            // Applies patch to the game to skip the starting question(s).
-            this.PatchGame(game, gameDetection.GameId);
+            bool patchGameSetting = Properties.Settings.Default.patchGames;
+
+            if (patchGameSetting)
+            {
+                // Applies patch to the game to skip the starting question(s).
+                this.PatchGame(game, gameDetection.GameId);
+            }
 
             // Create the Interpreter to run this Game.
             this.interpreter = new Interpreter(game, userInput, screen.Pixels);

--- a/AGILE/AgileForm.cs
+++ b/AGILE/AgileForm.cs
@@ -7,6 +7,7 @@ using System.Configuration;
 using System.Diagnostics;
 using System.Drawing;
 using System.IO;
+using System.Linq;
 using System.Windows.Forms;
 using static AGI.Resource.Logic;
 
@@ -51,14 +52,14 @@ namespace AGILE
             this.Controls.Add(screen);
             this.Show();
             this.Activate();
-            this.StartGame(this.SelectGame(args));
+            this.StartGame(this.SelectGame(args), args);
         }
 
         /// <summary>
         /// Starts the given AGI Game.
         /// </summary>
         /// <param name="game">The Game from which we'll get all of the game data.</param>
-        private void StartGame(Game game)
+        private void StartGame(Game game, string[] args)
         {
             // Register the key event handlers for KeyUp, KeyDown, and KeyPress.
             UserInput userInput = new UserInput();
@@ -72,9 +73,12 @@ namespace AGILE
             Version appVersion = System.Reflection.Assembly.GetExecutingAssembly().GetName().Version;
             this.Text = $"AGILE v{appVersion.Major}.{appVersion.Minor}.{appVersion.Build}.{appVersion.Revision} | {gameDetection.GameName}";
 
+            // Get patch game settings from UI / Application properties
             bool patchGameSetting = Properties.Settings.Default.patchGames;
+            // Get patch game settings from command line args
+            bool patchGameArg = args.Contains("--patch-game");
 
-            if (patchGameSetting)
+            if (patchGameSetting || patchGameArg)
             {
                 // Applies patch to the game to skip the starting question(s).
                 this.PatchGame(game, gameDetection.GameId);

--- a/AGILE/App.config
+++ b/AGILE/App.config
@@ -34,6 +34,9 @@
                 <setting name="lastBrowsePath" serializeAs="String">
                         <value />
                 </setting>
+                <setting name="patchGames" serializeAs="String">
+                        <value>False</value>
+                </setting>
         </AGILE.Properties.Settings>
     </userSettings>
 </configuration>

--- a/AGILE/OptionsFrm.Designer.cs
+++ b/AGILE/OptionsFrm.Designer.cs
@@ -47,7 +47,7 @@ namespace AGILE
             // applyBtn
             // 
             this.applyBtn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.applyBtn.Location = new System.Drawing.Point(297, 176);
+            this.applyBtn.Location = new System.Drawing.Point(297, 186);
             this.applyBtn.Name = "applyBtn";
             this.applyBtn.Size = new System.Drawing.Size(75, 23);
             this.applyBtn.TabIndex = 1038;
@@ -59,7 +59,7 @@ namespace AGILE
             // okBtn
             // 
             this.okBtn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.okBtn.Location = new System.Drawing.Point(135, 176);
+            this.okBtn.Location = new System.Drawing.Point(135, 186);
             this.okBtn.Name = "okBtn";
             this.okBtn.Size = new System.Drawing.Size(75, 23);
             this.okBtn.TabIndex = 1036;
@@ -72,7 +72,7 @@ namespace AGILE
             // 
             this.cancelBtn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.cancelBtn.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.cancelBtn.Location = new System.Drawing.Point(216, 176);
+            this.cancelBtn.Location = new System.Drawing.Point(216, 186);
             this.cancelBtn.Name = "cancelBtn";
             this.cancelBtn.Size = new System.Drawing.Size(75, 23);
             this.cancelBtn.TabIndex = 1037;
@@ -170,9 +170,10 @@ namespace AGILE
             this.patchGameChkBox.AutoSize = true;
             this.patchGameChkBox.Location = new System.Drawing.Point(18, 141);
             this.patchGameChkBox.Name = "patchGameChkBox";
-            this.patchGameChkBox.Size = new System.Drawing.Size(297, 17);
+            this.patchGameChkBox.Size = new System.Drawing.Size(297, 30);
             this.patchGameChkBox.TabIndex = 1040;
-            this.patchGameChkBox.Text = "Patch Game (Skips questions in KQ4, LSL, MH1 and GR)";
+            this.patchGameChkBox.Text = "Patch Game (Skips questions in KQ4, LSL, MH1 and GR)\r\nRestart required";
+            this.patchGameChkBox.TextAlign = System.Drawing.ContentAlignment.TopLeft;
             this.patchGameChkBox.UseVisualStyleBackColor = true;
             // 
             // OptionsFrm
@@ -180,7 +181,7 @@ namespace AGILE
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.cancelBtn;
-            this.ClientSize = new System.Drawing.Size(384, 211);
+            this.ClientSize = new System.Drawing.Size(384, 221);
             this.Controls.Add(this.patchGameChkBox);
             this.Controls.Add(this.runInAgileChkBox);
             this.Controls.Add(this.xmlGrpBox);
@@ -189,8 +190,8 @@ namespace AGILE
             this.Controls.Add(this.cancelBtn);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MaximizeBox = false;
-            this.MaximumSize = new System.Drawing.Size(400, 250);
-            this.MinimumSize = new System.Drawing.Size(400, 250);
+            this.MaximumSize = new System.Drawing.Size(400, 260);
+            this.MinimumSize = new System.Drawing.Size(400, 260);
             this.Name = "OptionsFrm";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "AGILE Options";

--- a/AGILE/OptionsFrm.Designer.cs
+++ b/AGILE/OptionsFrm.Designer.cs
@@ -40,13 +40,14 @@ namespace AGILE
             this.xmlEditorTxtBox = new System.Windows.Forms.TextBox();
             this.toolTip = new System.Windows.Forms.ToolTip(this.components);
             this.runInAgileChkBox = new System.Windows.Forms.CheckBox();
+            this.patchGameChkBox = new System.Windows.Forms.CheckBox();
             this.xmlGrpBox.SuspendLayout();
             this.SuspendLayout();
             // 
             // applyBtn
             // 
             this.applyBtn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.applyBtn.Location = new System.Drawing.Point(297, 141);
+            this.applyBtn.Location = new System.Drawing.Point(297, 176);
             this.applyBtn.Name = "applyBtn";
             this.applyBtn.Size = new System.Drawing.Size(75, 23);
             this.applyBtn.TabIndex = 1038;
@@ -58,7 +59,7 @@ namespace AGILE
             // okBtn
             // 
             this.okBtn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.okBtn.Location = new System.Drawing.Point(135, 141);
+            this.okBtn.Location = new System.Drawing.Point(135, 176);
             this.okBtn.Name = "okBtn";
             this.okBtn.Size = new System.Drawing.Size(75, 23);
             this.okBtn.TabIndex = 1036;
@@ -71,7 +72,7 @@ namespace AGILE
             // 
             this.cancelBtn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.cancelBtn.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.cancelBtn.Location = new System.Drawing.Point(216, 141);
+            this.cancelBtn.Location = new System.Drawing.Point(216, 176);
             this.cancelBtn.Name = "cancelBtn";
             this.cancelBtn.Size = new System.Drawing.Size(75, 23);
             this.cancelBtn.TabIndex = 1037;
@@ -164,12 +165,24 @@ namespace AGILE
             this.runInAgileChkBox.Text = "Add \"Run in Agile\" folder context menu item";
             this.runInAgileChkBox.UseVisualStyleBackColor = true;
             // 
+            // patchGameChkBox
+            // 
+            this.patchGameChkBox.AutoSize = true;
+            this.patchGameChkBox.Location = new System.Drawing.Point(18, 141);
+            this.patchGameChkBox.Name = "patchGameChkBox";
+            this.patchGameChkBox.Size = new System.Drawing.Size(297, 17);
+            this.patchGameChkBox.TabIndex = 1040;
+            this.patchGameChkBox.Text = "Patch Game (Skips questions in KQ4, LSL, MH1 and GR)";
+            this.patchGameChkBox.UseVisualStyleBackColor = true;
+            this.patchGameChkBox.CheckedChanged += new System.EventHandler(this.checkBox1_CheckedChanged);
+            // 
             // OptionsFrm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.cancelBtn;
-            this.ClientSize = new System.Drawing.Size(384, 176);
+            this.ClientSize = new System.Drawing.Size(384, 211);
+            this.Controls.Add(this.patchGameChkBox);
             this.Controls.Add(this.runInAgileChkBox);
             this.Controls.Add(this.xmlGrpBox);
             this.Controls.Add(this.applyBtn);
@@ -177,8 +190,8 @@ namespace AGILE
             this.Controls.Add(this.cancelBtn);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MaximizeBox = false;
-            this.MaximumSize = new System.Drawing.Size(400, 215);
-            this.MinimumSize = new System.Drawing.Size(400, 215);
+            this.MaximumSize = new System.Drawing.Size(400, 250);
+            this.MinimumSize = new System.Drawing.Size(400, 250);
             this.Name = "OptionsFrm";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "AGILE Options";
@@ -203,5 +216,6 @@ namespace AGILE
         private System.Windows.Forms.ToolTip toolTip;
         private System.Windows.Forms.CheckBox runInAgileChkBox;
         private System.Windows.Forms.CheckBox systemXMLDefaultChkBox;
+        private System.Windows.Forms.CheckBox patchGameChkBox;
     }
 }

--- a/AGILE/OptionsFrm.Designer.cs
+++ b/AGILE/OptionsFrm.Designer.cs
@@ -174,7 +174,6 @@ namespace AGILE
             this.patchGameChkBox.TabIndex = 1040;
             this.patchGameChkBox.Text = "Patch Game (Skips questions in KQ4, LSL, MH1 and GR)";
             this.patchGameChkBox.UseVisualStyleBackColor = true;
-            this.patchGameChkBox.CheckedChanged += new System.EventHandler(this.checkBox1_CheckedChanged);
             // 
             // OptionsFrm
             // 

--- a/AGILE/OptionsFrm.cs
+++ b/AGILE/OptionsFrm.cs
@@ -269,5 +269,10 @@ namespace AGILE
         }
 
         #endregion Extra Methods
+
+        private void checkBox1_CheckedChanged(object sender, EventArgs e)
+        {
+
+        }
     }
 }

--- a/AGILE/OptionsFrm.cs
+++ b/AGILE/OptionsFrm.cs
@@ -72,6 +72,12 @@ namespace AGILE
                 runInAgileChkBox.Checked = false;
             else
                 runInAgileChkBox.Checked = true;
+
+            // Get value of patchGames
+            if (patchGames.HasValue)
+            {
+                patchGameChkBox.Checked = Properties.Settings.Default.patchGames;
+            }
         }
 
         /// <summary>

--- a/AGILE/OptionsFrm.cs
+++ b/AGILE/OptionsFrm.cs
@@ -14,6 +14,7 @@ namespace AGILE
         #region Declares, Imports. etc.
 
         public static bool? useSystemXMLDefault = Properties.Settings.Default.useSystemXMLDefault;
+        public static bool? patchGames = Properties.Settings.Default.patchGames;
         private static string xmlEditor = Properties.Settings.Default.xmlEditor;
         private static string currentXMLEditor = null;
         public static bool nullXML = false;
@@ -261,6 +262,8 @@ namespace AGILE
 
             #endregion Set directory context menu
 
+            Properties.Settings.Default.patchGames = patchGameChkBox.Checked;
+
             Properties.Settings.Default.Save();
 
             // Open user config if options was called from trying to open config without XML editor being specified
@@ -269,10 +272,5 @@ namespace AGILE
         }
 
         #endregion Extra Methods
-
-        private void checkBox1_CheckedChanged(object sender, EventArgs e)
-        {
-
-        }
     }
 }

--- a/AGILE/Properties/Settings.Designer.cs
+++ b/AGILE/Properties/Settings.Designer.cs
@@ -118,5 +118,17 @@ namespace AGILE.Properties {
                 this["lastBrowsePath"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool patchGames {
+            get {
+                return ((bool)(this["patchGames"]));
+            }
+            set {
+                this["patchGames"] = value;
+            }
+        }
     }
 }

--- a/AGILE/Properties/Settings.settings
+++ b/AGILE/Properties/Settings.settings
@@ -26,5 +26,8 @@
     <Setting Name="lastBrowsePath" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
+    <Setting Name="patchGames" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>


### PR DESCRIPTION
AGILE currently **always** patches the game, though that's the ideal way, it might result in bugs (saw the discussion about Gold Rush) and its not the full game experience.

This adds a new option in the options form to patch the game.

By default, its false, so user experiences the full game (including copy protection / age verification).

![Capture](https://user-images.githubusercontent.com/285941/202871631-a27cbb3e-58dc-4e53-90a3-080e7b7ae4e5.PNG)

it also accepts a command line option `--patch-game`, for us command line users, to patch the game.

The `Restart Required` text is needed since the current patch function starts immediately.