### PR TITLE
folderbrowser cleanup

### DIFF
--- a/AGILE/AgileForm.cs
+++ b/AGILE/AgileForm.cs
@@ -282,7 +282,6 @@ namespace AGILE
                         }
 
                         folderDialog.ShowNewFolderButton = false;
-                        folderDialog.RootFolder = Environment.SpecialFolder.MyComputer;
                         folderDialog.Description = prompt;
                         folderDialog.SelectedPath = !String.IsNullOrEmpty(Properties.Settings.Default.lastBrowsePath) ?
                                 Properties.Settings.Default.lastBrowsePath : gameFolder;


### PR DESCRIPTION
removes the rootfolder property and associated code that tries to force a root folder. The dialog will always use its default root folder instead